### PR TITLE
Fix 3-component key generation

### DIFF
--- a/internal/ui/tabs/bitwise_calculator.go
+++ b/internal/ui/tabs/bitwise_calculator.go
@@ -610,6 +610,7 @@ func (bc *BitwiseCalculator) onGenerateKey(bitLen int) func() {
 		}
 
 		if num == 3 && len(components) > 2 {
+			bc.comp3.SetText(strings.ToUpper(components[2]))
 			data3, err3 := hex.DecodeString(components[2])
 			if err3 == nil && len(data3) > 0 {
 				if len(data3) == 32 {


### PR DESCRIPTION
## Summary
- ensure the third key component value is displayed when generating a key with three components

## Testing
- `make test` *(fails: go toolchain download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68417f5ec3d0832683b011cca66368f5